### PR TITLE
Fix float parsing with invariant culture

### DIFF
--- a/CatsMCP.Infrastructure/Repositories/CatDbContext.cs
+++ b/CatsMCP.Infrastructure/Repositories/CatDbContext.cs
@@ -1,6 +1,7 @@
 using CatsMCP.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using System.Globalization;
 
 namespace CatsMCP.Infrastructure.Repositories;
 
@@ -16,7 +17,7 @@ public class CatDbContext : DbContext
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         var converter = new ValueConverter<float[]?, string?>(
-            v => v == null ? null : string.Join(',', v),
+            v => v == null ? null : string.Join(',', v.Select(f => f.ToString(CultureInfo.InvariantCulture))),
             v => string.IsNullOrEmpty(v) ? null : ParseFloatArray(v));
 
         modelBuilder.Entity<Cat>()
@@ -32,6 +33,6 @@ public class CatDbContext : DbContext
 
     private static float[]? ParseFloatArray(string value)
     {
-        return value.Split(',').Select(float.Parse).ToArray();
+        return value.Split(',').Select(v => float.Parse(v, CultureInfo.InvariantCulture)).ToArray();
     }
 }


### PR DESCRIPTION
## Summary
- ensure `ParseFloatArray` parses floats using `CultureInfo.InvariantCulture`
- join float arrays with invariant culture formatting

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858767408e883218551dc46d2f99c45