### PR TITLE
Refactor CatService API to generic

### DIFF
--- a/CatsMCP.Application/Interfaces/Services/CatService.cs
+++ b/CatsMCP.Application/Interfaces/Services/CatService.cs
@@ -3,7 +3,7 @@ using CatsMCP.Domain.Entities;
 
 namespace CatsMCP.Application.Services;
 
-public class CatService : ICatService
+public class CatService : ICatService<Cat>
 {
     private readonly ICatRepository repository;
 
@@ -12,14 +12,13 @@ public class CatService : ICatService
         this.repository = repository;
     }
 
-    public async Task<List<object>> GetCats()
+    public Task<List<Cat>> GetCats()
     {
-        var result = await repository.GetCats();
-        return result.Cast<object>().ToList();
+        return repository.GetCats();
     }
 
-    public async Task<object?> GetCat(string name)
+    public Task<Cat?> GetCat(string name)
     {
-        return await repository.GetCat(name);
+        return repository.GetCat(name);
     }
 }

--- a/CatsMCP.Application/Interfaces/Services/CatServiceEn.cs
+++ b/CatsMCP.Application/Interfaces/Services/CatServiceEn.cs
@@ -3,7 +3,7 @@ using CatsMCP.Domain.Entities;
 
 namespace CatsMCP.Application.Services;
 
-public class CatServiceEn : ICatService
+public class CatServiceEn : ICatService<CatEn>
 {
     private readonly ICatRepositoryEn repository;
 
@@ -12,14 +12,13 @@ public class CatServiceEn : ICatService
         this.repository = repository;
     }
 
-    public async Task<List<object>> GetCats()
+    public Task<List<CatEn>> GetCats()
     {
-        var result = await repository.GetCats();
-        return result.Cast<object>().ToList();
+        return repository.GetCats();
     }
 
-    public async Task<object?> GetCat(string name)
+    public Task<CatEn?> GetCat(string name)
     {
-        return await repository.GetCat(name);
+        return repository.GetCat(name);
     }
 }

--- a/CatsMCP.Application/Interfaces/Services/ICatService.cs
+++ b/CatsMCP.Application/Interfaces/Services/ICatService.cs
@@ -1,7 +1,7 @@
 namespace CatsMCP.Application.Services;
 
-public interface ICatService
+public interface ICatService<out T>
 {
-    Task<List<object>> GetCats();
-    Task<object?> GetCat(string name);
+    Task<List<T>> GetCats();
+    Task<T?> GetCat(string name);
 }

--- a/CatsMCP.WebApi/CatTools.cs
+++ b/CatsMCP.WebApi/CatTools.cs
@@ -9,14 +9,14 @@ namespace CatsMCP.WebApi;
 public static class CatTools
 {
     [McpServerTool, Description("Get a list of cats.")]
-    public static async Task<string> GetCats(ICatService catService)
+    public static async Task<string> GetCats(ICatService<object> catService)
     {
         var cats = await catService.GetCats();
         return JsonSerializer.Serialize(cats);
     }
 
     [McpServerTool, Description("Get a cat by name.")]
-    public static async Task<string> GetCat(ICatService catService, [Description("The name of the cat to get details for")] string name)
+    public static async Task<string> GetCat(ICatService<object> catService, [Description("The name of the cat to get details for")] string name)
     {
         var cat = await catService.GetCat(name);
         return JsonSerializer.Serialize(cat);

--- a/CatsMCP.WebApi/Program.cs
+++ b/CatsMCP.WebApi/Program.cs
@@ -1,6 +1,7 @@
 using CatsMCP.Application.Services;
 using CatsMCP.Application.Interfaces.Repositories;
 using CatsMCP.Infrastructure.Repositories;
+using CatsMCP.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -24,15 +25,15 @@ if (language == "en")
 {
     builder.Services
         .AddScoped<ICatRepositoryEn, CatRepositoryEn>()
-        .AddScoped<CatServiceEn>()
-        .AddScoped<ICatService>(sp => sp.GetRequiredService<CatServiceEn>());
+        .AddScoped<ICatService<CatEn>, CatServiceEn>()
+        .AddScoped<ICatService<object>>(sp => sp.GetRequiredService<ICatService<CatEn>>());
 }
 else
 {
     builder.Services
         .AddScoped<ICatRepository, CatRepository>()
-        .AddScoped<CatService>()
-        .AddScoped<ICatService>(sp => sp.GetRequiredService<CatService>());
+        .AddScoped<ICatService<Cat>, CatService>()
+        .AddScoped<ICatService<object>>(sp => sp.GetRequiredService<ICatService<Cat>>());
 }
 
 builder.Services


### PR DESCRIPTION
## Summary
- define generic `ICatService<T>` interface
- update `CatService` and `CatServiceEn` to return concrete `Cat` and `CatEn`
- adapt `CatTools` to depend on `ICatService<object>`
- update dependency registration in `Program.cs` for the new generic services

## Testing
- `dotnet build --no-restore` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858768639588321a89c40a8f18ac831